### PR TITLE
Method for apply generic filters using default operator '='

### DIFF
--- a/src/Model/Criteria.php
+++ b/src/Model/Criteria.php
@@ -224,4 +224,33 @@ class Criteria extends PhalconModel\Criteria
 
         return $this;
     }
+
+    /**
+     * Apply $filters for query
+     *
+     * @param array $filters
+     * @param bool  $strict Exception return if property not exists on model
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    public function applyFilters(array $filters, bool $strict = false)
+    {
+        foreach ($filters ?? [] as $filterName => $filterValue) {
+            if ($filterValue === null) {
+                continue;
+            }
+
+            if (!property_exists($this->getModelName(), $filterName)) {
+                if ($strict) {
+                    throw new \Exception("Param $filterName not found for class {$this->getModelName()}");
+                }
+                continue;
+            }
+
+            $this->andWhere("{$this->getAlias()}.{$filterName} = :{$filterName}:", [$filterName => $filterValue]);
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Method to apply generic filters using default operator '='

**Ex:** 
```php
$query->applyFilters([
      'status' => 1,
      'name' => 'Jow'
])->execute();
```

Return Model for **name** = Jow and **status** = 1