### PR TITLE
Add models protected params to json serialize 

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -136,7 +136,7 @@ class Model extends PhalconModel implements \JsonSerializable
         $myData  = [];
         $child   = new static();
         $reflect = new \ReflectionObject($child);
-        $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC);
+        $props   = $reflect->getProperties(\ReflectionProperty::IS_PUBLIC|\ReflectionProperty::IS_PROTECTED);
         foreach ($props as $prop) {
             $propName = $prop->getName();
             if (substr($propName, 0, 1) !== '_') {


### PR DESCRIPTION
As novas classes de modelo tem atributos protegidos que não são serializados no json_encode mas fazem parte do **column map**